### PR TITLE
Change time.clock to time.perf_counter

### DIFF
--- a/ping.py
+++ b/ping.py
@@ -212,7 +212,7 @@ __description__ = 'A pure python ICMP ping implementation using raw sockets.'
 
 if sys.platform == "win32":
     # On Windows, the best timer is time.clock()
-    default_timer = time.clock
+    default_timer = time.perf_counter
 else:
     # On most other platforms the best timer is time.time()
     default_timer = time.time


### PR DESCRIPTION
time.clock has been deprecated in Python 3.3 and will be removed from Python 3.8: use time.perf_counter or time.process_time instead